### PR TITLE
Deployment for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,25 @@ try {
 } catch {}
 
 function getNodePath() {
-    if (app.isPackaged) {
-        // Use Electron's node binary in packaged app
+  if (app.isPackaged) {
+    switch (process.platform) {
+      case 'darwin':
         return path.join(process.resourcesPath, "node", "macos", "node")
-    } else {
-        // Use system node in development
-        return 'node';
+      case 'win32':
+        return path.join(process.resourcesPath, "node", "windows", "node.exe")
+      case 'linux':
+        return path.join(process.resourcesPath, "node", "linux", "node")
     }
+  } else {
+    switch (process.platform) {
+      case 'darwin':
+        return path.join(__dirname, "resources", "node", "macos", "node")
+      case 'win32':
+        return path.join(__dirname, "resources", "node", "windows", "node.exe")
+      case 'linux':
+        return path.join(__dirname, "resources", "node", "linux", "node")
+    }
+  }
 }
 const nodePath = getNodePath();
 console.log(process.resource)

--- a/index.js
+++ b/index.js
@@ -65,9 +65,12 @@ app.on('window-all-closed', () => {
     process.stdout.write(data);
   });
 
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
+  // Wait for the logout process to complete only then quit
+  ptyProcess.onExit((exitCode) => {
+    if (process.platform !== 'darwin') {
+      app.quit()
+    }
+  });
 })
 
 ipcMain.handle("login:submit", (event, args) => {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const index_html= 'index.html';
 const uplaod_html = 'upload.html'
 
 let mainWindow;
-let file_folder_path = "/Users/yapch/Desktop/Orico_2Bay_NAS_MetaCube.jpeg";
+let file_path = '';
+let folder_path = '';
 
 try {
 	require('electron-reloader')(module);
@@ -111,18 +112,34 @@ ipcMain.handle("upload:submit", (event, args) => {
   
   console.log(`Dry Run: ${dry_run}  Album: ${album}  Recursive: ${recursive}`)
   
-  const ptyProcess = pty.spawn(nodePath, [immich_cli_file,'upload', dry_run, album, recursive, ...file_folder_path])
-  ptyProcess.onData((data) => {
-    process.stdout.write(data);
-    event.sender.send('output-message', data);
-  });
+  if (file_path) {
+    const ptyProcess = pty.spawn(nodePath, [immich_cli_file,'upload', dry_run, album, recursive, ...file_path])
+    ptyProcess.onData((data) => {
+      process.stdout.write(data);
+      event.sender.send('output-message', data);
+    });
+  } else if (folder_path) {
+    const ptyProcess = pty.spawn(nodePath, [immich_cli_file,'upload', dry_run, album, recursive, ...folder_path])
+    ptyProcess.onData((data) => {
+      process.stdout.write(data);
+      event.sender.send('output-message', data);
+    });
+  }
   
 })
 
-ipcMain.handle("open-dialog-for-file-folder", (event) => {
-  file_folder_path = dialog.showOpenDialogSync({ properties: ['openFile', 'openDirectory', 'multiSelections'] })
-  console.log(file_folder_path)
-  return file_folder_path
+ipcMain.handle("open-dialog-for-file", (event) => {
+  folder_path = '';
+  file_path = dialog.showOpenDialogSync({ properties: ['openFile', 'multiSelections'] })
+  console.log(file_path)
+  return file_path
+})
+
+ipcMain.handle("open-dialog-for-folder", (event) => {
+  file_path = '';
+  folder_path = dialog.showOpenDialogSync({ properties: ['openDirectory', 'multiSelections'] })
+  console.log(folder_path)
+  return folder_path
 })
 
 function console_logs_data(cli) {

--- a/preload.js
+++ b/preload.js
@@ -1,7 +1,8 @@
 const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('openDialog', {
-  file_folder: () => ipcRenderer.invoke('open-dialog-for-file-folder')
+  file: () => ipcRenderer.invoke('open-dialog-for-file'),
+  folder: () => ipcRenderer.invoke('open-dialog-for-folder')
 })
 
 contextBridge.exposeInMainWorld('immich', {

--- a/renderer.js
+++ b/renderer.js
@@ -20,12 +20,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const pathButton = document.getElementById('file-folder-selection-button')
+  const filePathButton = document.getElementById('file-selection-button')
+  const folderPathButton = document.getElementById('folder-selection-button')
   const outputPathField = document.getElementById('output-path-field')
-  if (pathButton) {
-    pathButton.addEventListener('click', async () => {
-      const fileFolderPath = await window.openDialog.file_folder();
-      outputPathField.value = fileFolderPath;
+  if (filePathButton && folderPathButton) {
+    filePathButton.addEventListener('click', async () => {
+      const filePath = await window.openDialog.file();
+      outputPathField.value = filePath;
+    })
+    folderPathButton.addEventListener('click', async () => {
+      const folderPath = await window.openDialog.folder();
+      outputPathField.value = folderPath;
     })
   }
   

--- a/upload.html
+++ b/upload.html
@@ -19,7 +19,8 @@
             <label for="output-path-field">📁 Select Files or Folder</label>
             <div class="file-selection">
                 <input type="text" id="output-path-field" placeholder="Choose files or folder..." readonly>
-                <button type="button" id="file-folder-selection-button">Browse</button>
+                <button type="button" id="file-selection-button">Files</button>
+                <button type="button" id="folder-selection-button">Folders</button>
             </div>
         </div>
 


### PR DESCRIPTION
So it is confirmed that the electron-forge configuration is the same for all OS. No changes needed on Electron Forge. However because of some different technical functionality between macOS and Windows & Linux (for showDialogBoxSync) the files and folders path selection is separated into two buttons.

Also the app require node binary to run immich cli and therefore different OS come with different node binary and therefore on execution a new section of code is made to accommodate this.